### PR TITLE
Job's order matches in-game

### DIFF
--- a/js/services/actions.js
+++ b/js/services/actions.js
@@ -2,14 +2,14 @@
   'use strict';
 
   var allClasses = [
-    "Alchemist",
-    "Armorer",
-    "Blacksmith",
     "Carpenter",
-    "Culinarian",
+    "Blacksmith",
+    "Armorer",
     "Goldsmith",
     "Leatherworker",
-    "Weaver"
+    "Weaver",
+    "Alchemist",
+    "Culinarian"
   ];
 
   // Seems 'skillID' doesn't even do anything lol


### PR DESCRIPTION
Fixed https://github.com/NotRanged/NotRanged.github.io/issues/76.

The order of the drop-down menu and class list is now the same as in the game.

However, I am not sure about the order of the English client as I play with the Japanese client.
If the current alphabetical order is easier to use, please let me know.